### PR TITLE
Replacing oracle with guru since oracle was deprecated

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,7 +38,7 @@ RUN gem install tmuxinator
 RUN go get github.com/nsf/gocode \
            golang.org/x/tools/cmd/goimports \
            github.com/rogpeppe/godef \
-           golang.org/x/tools/cmd/oracle \
+           golang.org/x/tools/cmd/guru \
            golang.org/x/tools/cmd/gorename \
            github.com/golang/lint/golint \
            github.com/kisielk/errcheck \


### PR DESCRIPTION
Oracle was renamed to guru and noticed this was updated in the go-ide Dockerfile. 

Here's the link explaining golang oracle's depreciation https://godoc.org/golang.org/x/tools/cmd/oracle
