### PR TITLE
-container was not in the actual path.

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Building the Container
 ----------------------
 Nothing special if you already have Docker installed:
 
-    $ git clone https://github.com/saturnism/go-ide-container
-    $ cd go-ide-container
-    $ docker build -t go-ide-container .
+    $ git clone https://github.com/saturnism/go-ide
+    $ cd go-ide
+    $ docker build -t go-ide .
 


### PR DESCRIPTION
The code example to clone and cd into directory needed to have the '-container' suffix removed.